### PR TITLE
Remove custom options except for required

### DIFF
--- a/lib/informant.rb
+++ b/lib/informant.rb
@@ -239,7 +239,7 @@ module Informant
 
       # Remove custom options from options hash so things like
       # <tt>include_blank</tt> aren't added as HTML attributes.
-      options.reject!{ |i,j| @@custom_options.include? i }
+      options.reject! { |i,j| @@custom_options.include?(i) && i != :required }
 
       locals = {
         :element     => yield,

--- a/test/informant_test.rb
+++ b/test/informant_test.rb
@@ -8,4 +8,13 @@ class InformantTest < ActionView::TestCase
     b = Informant::Standard.new(:car, Object.new, @controller, {}) { p }
     assert_equal "", b
   end
+
+  test 'option required should be rendered' do
+    form = Informant::Standard.new(:cc, OpenStruct.new(number: '123'), self, {})
+    element = form.text_field(:number, required: true)
+    expected = <<-EOT
+    <div id=\"cc_number_field\" class=\"field\"><label>Number<span class=\"required\">*</span></label><br /><input required=\"required\" type=\"text\" value=\"123\" name=\"cc[number]\" id=\"cc_number\" /></div>
+    EOT
+    assert_equal expected.strip, element.gsub(/\n\s+/,'').strip
+  end
 end


### PR DESCRIPTION
Option 'required' is needed in the input field, it can't be moved to label.